### PR TITLE
ci: fix `rbenv: ...versions/3.0.1 already exists` error

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -117,7 +117,7 @@ workflows:
             #!/usr/bin/env bash
             set -e
             
-            rbenv install
+            rbenv install --skip-existing
     - script@1:
         title: Bundle install
         inputs:


### PR DESCRIPTION
# Description
The error is present on Bitrise when cache is pulled

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data before every commit, including API endpoints and keys
- [ ] I ran `fastlane ci` without errors
