### PR TITLE
ci: send Slack message only on failed tests

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -82,6 +82,7 @@ workflows:
         - scheme: IntegrationTests
         - should_build_before_test: 'no'
     - slack@3:
+        run_if: .IsBuildFailed
         inputs:
         - channel: ''
         - webhook_url: "$SLACK_CHANNEL_WEBHOOK"


### PR DESCRIPTION
# Description
Changed Slack notification to be sent only on failed integration tests to reduce the amount of daily notifications.

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data before every commit, including API endpoints and keys
- [ ] I ran `fastlane ci` without errors
